### PR TITLE
Fix address space leak

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -158,7 +158,7 @@ int wmain(int argc, wchar_t *argv[])
 
     bool is_ok = transacted_hollowing(targetPath, payladBuf, (DWORD) payloadSize);
 
-    free_buffer(payladBuf, payloadSize);
+    free_buffer(payladBuf);
     if (is_ok) {
         std::cerr << "[+] Done!" << std::endl;
     } else {

--- a/util.cpp
+++ b/util.cpp
@@ -40,10 +40,10 @@ BYTE *buffer_payload(wchar_t *filename, OUT size_t &r_size)
     return localCopyAddress;
 }
 
-void free_buffer(BYTE* buffer, size_t buffer_size)
+void free_buffer(BYTE* buffer)
 {
     if (buffer == NULL) return;
-    VirtualFree(buffer, buffer_size, MEM_DECOMMIT);
+    VirtualFree(buffer, 0, MEM_RELEASE);
 }
 
 wchar_t* get_file_name(wchar_t *full_path)

--- a/util.h
+++ b/util.h
@@ -3,7 +3,7 @@
 #include <Windows.h>
 
 BYTE *buffer_payload(wchar_t *filename, OUT size_t &r_size);
-void free_buffer(BYTE* buffer, size_t buffer_size);
+void free_buffer(BYTE* buffer);
 
 //get file name from the full path
 wchar_t* get_file_name(wchar_t *full_path);


### PR DESCRIPTION
Hello.
I'd like to open this PR because there's possibly address space leak on `free_buffer` function in `util.cpp` that would indeed leak address space of virtual memory.

```diff
-void free_buffer(BYTE* buffer, size_t buffer_size)
+void free_buffer(BYTE* buffer)
{
    if (buffer == NULL) return;
-    VirtualFree(buffer, buffer_size, MEM_DECOMMIT);
+    VirtualFree(buffer, 0, MEM_RELEASE);
}
```

It only decommits virtual memory and not releasing(VADs would remain).

This issue does not affect its behavior and not the big problem on this case but I refactored.
Thanks in advance.